### PR TITLE
Advance to "Validate assocs on prepare instead of normalization" commit.

### DIFF
--- a/integration/sqlite/all_test.exs
+++ b/integration/sqlite/all_test.exs
@@ -1,3 +1,4 @@
+Code.require_file "../../deps/ecto/integration_test/cases/assoc.exs", __DIR__
 Code.require_file "../../deps/ecto/integration_test/cases/interval.exs", __DIR__
 Code.require_file "../../deps/ecto/integration_test/cases/joins.exs", __DIR__
 Code.require_file "../../deps/ecto/integration_test/cases/migrator.exs", __DIR__

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Sqlite.Ecto.Mixfile do
   defp deps do
     [{:coverex, "~> 1.4.11", only: :test},
      {:ex_doc, "~> 0.14.5", only: :dev},
-     {:ecto, git: "https://github.com/scouten/ecto.git", ref: "00e0c417e53c2508cc6f879738df4beaf67fcfc8"},
+     {:ecto, git: "https://github.com/scouten/ecto.git", ref: "7081ae3e2ee62049f700a215d4c50deca506d1e4"},
      {:poison, "~> 1.0"},
      {:sqlitex, git: "https://github.com/scouten/sqlitex.git", ref: "c997c613a69ece59d8dd6b7e7ee557d4c4a1c709"}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -4,7 +4,7 @@
   "db_connection": {:git, "https://github.com/fishcakez/db_connection.git", "3e169b0b595276cc44fc935b200f428bd1abc08d", []},
   "decimal": {:hex, :decimal, "1.1.1", "a8ff5b673105e6cdaca96f799aeefc6f07142881b616c65db16e14e556b16e76", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "ecto": {:git, "https://github.com/scouten/ecto.git", "00e0c417e53c2508cc6f879738df4beaf67fcfc8", [ref: "00e0c417e53c2508cc6f879738df4beaf67fcfc8"]},
+  "ecto": {:git, "https://github.com/scouten/ecto.git", "7081ae3e2ee62049f700a215d4c50deca506d1e4", [ref: "7081ae3e2ee62049f700a215d4c50deca506d1e4"]},
   "esqlite": {:hex, :esqlite, "0.2.1", "0e2896f177180b33e5a8fe65342b4e81de46e0db59e4cbf6e8b9101e98d423fd", [:make, :rebar], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "hackney": {:hex, :hackney, "1.6.5", "8c025ee397ac94a184b0743c73b33b96465e85f90a02e210e86df6cbafaa5065", [:rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},


### PR DESCRIPTION
Happy new year! (First commits of 2016 to make it in!)

Now 111/612 of Ecto v2 commits.
