### PR TITLE
Changes to please the Elixir compiler

### DIFF
--- a/lib/sqlite_ecto/connection.ex
+++ b/lib/sqlite_ecto/connection.ex
@@ -814,7 +814,7 @@ if Code.ensure_loaded?(Sqlitex.Server) do
 
     # Decimals are the only type for which we care about the options:
     defp column_type(:decimal, opts=%{precision: precision}) do
-      scale = Dict.get(opts, :scale, 0)
+      scale = Map.get(opts, :scale, 0)
       "DECIMAL(#{precision},#{scale})"
     end
     # Simple column types.  Note that we ignore options like :size, :precision,
@@ -882,7 +882,7 @@ if Code.ensure_loaded?(Sqlitex.Server) do
     # Therefore the best option is just to remove the NOT NULL constraint when
     # we add new datetime columns.
     defp alter_table_suffix(_table, {:add, column, :datetime, opts}) do
-      opts = opts |> Enum.into(%{}) |> Dict.delete(:null)
+      opts = opts |> Enum.into(%{}) |> Map.delete(:null)
       change = {:add, column, :datetime, opts}
       ["ADD COLUMN", column_definition(change)]
     end

--- a/lib/sqlite_ecto/connection.ex
+++ b/lib/sqlite_ecto/connection.ex
@@ -40,7 +40,7 @@ if Code.ensure_loaded?(Sqlitex.Server) do
         %Ecto.Query.Tagged{type: :binary, value: value} when is_binary(value) -> {:blob, value}
         %Ecto.Query.Tagged{value: value} -> value
         %{__struct__: _} = value -> value
-        %{} = value -> json_library.encode! value
+        %{} = value -> json_library().encode! value
         value -> value
       end)
 
@@ -254,7 +254,7 @@ if Code.ensure_loaded?(Sqlitex.Server) do
     # (below), call func.(), and drop the table afterwards.  Returns the
     # result of func.().
     defp with_temp_table(pid, returning, func) do
-      tmp = "t_" <> random_id
+      tmp = "t_" <> random_id()
       fields = Enum.join(returning, ", ")
       results = case exec(pid, "CREATE TEMP TABLE #{tmp} (#{fields})") do
         {:error, _} = err -> err
@@ -267,7 +267,7 @@ if Code.ensure_loaded?(Sqlitex.Server) do
     # Create a trigger to capture the changes from our query, call func.(),
     # and drop the trigger when done.  Returns the result of func.().
     defp with_temp_trigger(pid, table, tmp_tbl, returning, query, ref, func) do
-      tmp = "tr_" <> random_id
+      tmp = "tr_" <> random_id()
       fields = Enum.map_join(returning, ", ", &"#{ref}.#{&1}")
       sql = """
       CREATE TEMP TRIGGER #{tmp} AFTER #{query} ON main.#{table} BEGIN
@@ -908,7 +908,7 @@ if Code.ensure_loaded?(Sqlitex.Server) do
     # the func parameter, rollback our changes. Returns the result of the call
     # to func.
     defp with_savepoint(pid, func) do
-      sp = "sp_" <> random_id
+      sp = "sp_" <> random_id()
       :ok = exec(pid, savepoint(sp))
       result = safe_call(pid, func, sp)
       if is_tuple(result) and elem(result, 0) == :error do

--- a/mix.exs
+++ b/mix.exs
@@ -7,16 +7,16 @@ defmodule Sqlite.Ecto.Mixfile do
      name: "Sqlite.Ecto2",
      elixir: "~> 1.2",
      elixirc_options: [warnings_as_errors: true],
-     deps: deps,
+     deps: deps(),
 
      # testing
      build_per_environment: false,
-     test_paths: test_paths,
+     test_paths: test_paths(),
      test_coverage: [tool: Coverex.Task, coveralls: true],
 
      # hex
-     description: description,
-     package: package,
+     description: description(),
+     package: package(),
 
      # docs
      docs: [main: Sqlite.Ecto]]


### PR DESCRIPTION
Since the compiler option `warnings-as-errors` was enabled in e746adc, I replaced `Dict` by `Map` and fixed all the function calls (it makes `json_library` uglier, but the compiler doesn't complain anymore).