### PR TITLE
Reduce the number of test builds to 5 so as to make Travis run faster.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: elixir
 
 elixir:
-  - 1.3
-  - 1.4.0
+  - 1.3.4
   - 1.4.2
 
 otp_release:
@@ -12,10 +11,8 @@ otp_release:
 
 matrix:
   exclude:
-  - elixir: 1.3
+  - elixir: 1.3.4
     otp_release: 19.2
-  - elixir: 1.4.0
-    otp_release: 18.0
 
 script:
   - mix deps.get && ./integration/hack_out_incompatible_tests.sh && mix test --cover

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Sqlite.Ecto.Mixfile do
     [app: :sqlite_ecto2,
      version: "2.0.0-dev.1",
      name: "Sqlite.Ecto2",
-     elixir: "~> 1.3.4",
+     elixir: "~> 1.3.4 or ~> 1.4",
      elixirc_options: [warnings_as_errors: true],
      deps: deps(),
      elixirc_paths: elixirc_paths(Mix.env),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Sqlite.Ecto.Mixfile do
     [app: :sqlite_ecto2,
      version: "2.0.0-dev.1",
      name: "Sqlite.Ecto2",
-     elixir: "~> 1.3",
+     elixir: "~> 1.3.4",
      elixirc_options: [warnings_as_errors: true],
      deps: deps(),
      elixirc_paths: elixirc_paths(Mix.env),


### PR DESCRIPTION
Adopt 1.3.4 as minimum Elixir version.