### PR TITLE
Use the name `Sqlite.Ecto2` consistently in API names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ _26 March 2017_
 
 ## Bug fixes
 
-* **BREAKING CHANGE:** Use the name `Sqlite.Ecto2` consistently in API names. Discontinue use of name `Sqlite.Ecto` (without the `2).
+* **BREAKING CHANGE:** Use the name `Sqlite.Ecto2` consistently in API names. Discontinue use of name `Sqlite.Ecto` (without the `2`)
 * Ensure db_connection app is started before relying on it.
 
 ## v2.0.0-dev.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is a major rewrite of the previously-existing [`sqlite_ecto`]((https://gith
 
 ## v2.0.0-dev.2
 
-_pending_
+_26 March 2017_
 
 ## Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,18 @@
 
 This is a major rewrite of the previously-existing [`sqlite_ecto`]((https://github.com/jazzyb/sqlite_ecto) that adds support for Ecto 2.1+.
 
-## v2.0.0-dev.0
+## v2.0.0-dev.2
 
-_18 March 2017_
+_pending_
+
+## Bug fixes
+
+* **BREAKING CHANGE:** Use the name `Sqlite.Ecto2` consistently in API names. Discontinue use of name `Sqlite.Ecto` (without the `2).
+* Ensure db_connection app is started before relying on it.
+
+## v2.0.0-dev.1
+
+_21 March 2017_
 
 Initial public release of version 2.0 (alpha quality).
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To use the adapter in your repo:
 defmodule MyApp.Repo do
   use Ecto.Repo,
     otp_app: :my_app,
-    adapter: Sqlite.Ecto
+    adapter: Sqlite.Ecto2
 end
 ```
 
@@ -115,7 +115,7 @@ Several Ecto constraints are not fully implemented in `sqlite_ecto2` because SQL
 
 ## Silently Ignored Options
 
-There are a few Ecto options which `Sqlite.Ecto` silently ignores because SQLite does not support them and raising an error on them does not make sense:
+There are a few Ecto options which `Sqlite.Ecto2` silently ignores because SQLite does not support them and raising an error on them does not make sense:
 
 * Most column options will ignore `size`, `precision`, and `scale` constraints on types because columns in SQLite have no types, and SQLite will not coerce any stored value. Thus, all "strings" are `TEXT` and "numerics" will have arbitrary precision regardless of the declared column constraints. The lone exception to this rule are Decimal types which accept `precision` and `scale` options because these constraints are handled in the driver software, not the SQLite database.
 

--- a/integration/sqlite/test_helper.exs
+++ b/integration/sqlite/test_helper.exs
@@ -46,7 +46,7 @@ Code.require_file "../../deps/ecto/integration_test/support/migration.exs", __DI
 alias Ecto.Integration.TestRepo
 
 Application.put_env(:ecto, TestRepo,
-  adapter: Sqlite.Ecto,
+  adapter: Sqlite.Ecto2,
   database: "/tmp/test_repo.db",
   pool: Ecto.Adapters.SQL.Sandbox,
   ownership_pool: pool)
@@ -59,7 +59,7 @@ end
 alias Ecto.Integration.PoolRepo
 
 Application.put_env(:ecto, PoolRepo,
-  adapter: Sqlite.Ecto,
+  adapter: Sqlite.Ecto2,
   pool: DBConnection.Poolboy,
   database: "/tmp/test_repo.db",
   pool_size: 10)
@@ -84,15 +84,15 @@ defmodule Ecto.Integration.Case do
   end
 end
 
-{:ok, _} = Sqlite.Ecto.ensure_all_started(TestRepo, :temporary)
+{:ok, _} = Sqlite.Ecto2.ensure_all_started(TestRepo, :temporary)
 
 # Load support models and migration
 Code.require_file "../../deps/ecto/integration_test/support/schemas.exs", __DIR__
 Code.require_file "../../deps/ecto/integration_test/support/migration.exs", __DIR__
 
 # Load up the repository, start it, and run migrations
-_   = Sqlite.Ecto.storage_down(TestRepo.config)
-:ok = Sqlite.Ecto.storage_up(TestRepo.config)
+_   = Sqlite.Ecto2.storage_down(TestRepo.config)
+:ok = Sqlite.Ecto2.storage_up(TestRepo.config)
 
 {:ok, _pid} = TestRepo.start_link
 {:ok, _pid} = PoolRepo.start_link

--- a/lib/sqlite_ecto.ex
+++ b/lib/sqlite_ecto.ex
@@ -1,4 +1,4 @@
-defmodule Sqlite.Ecto do
+defmodule Sqlite.Ecto2 do
   @moduledoc ~S"""
   Ecto Adapter module for SQLite.
 
@@ -15,7 +15,7 @@ defmodule Sqlite.Ecto do
   These options should be set in the config file and require recompilation in
   order to make an effect.
 
-    * `:adapter` - The adapter name, in this case, `Sqlite.Ecto`
+    * `:adapter` - The adapter name, in this case, `Sqlite.Ecto2`
     * `:timeout` - The default timeout to use on queries, defaults to `5000`
 
   ### Connection options

--- a/lib/sqlite_ecto/connection.ex
+++ b/lib/sqlite_ecto/connection.ex
@@ -3,7 +3,7 @@ if Code.ensure_loaded?(Sqlitex.Server) do
   # TODO: Port changes to query composition made just before 2.1.0 release.
   # See https://github.com/elixir-ecto/ecto/compare/4a64a740e3c84342cadf6a1acef1e22ae454886e...d6d39bf018b7a601d999b1b8e246142d15205e0d
 
-  defmodule Sqlite.Ecto.Connection do
+  defmodule Sqlite.Ecto2.Connection do
     @moduledoc false
 
     @behaviour Ecto.Adapters.SQL.Connection

--- a/mix.exs
+++ b/mix.exs
@@ -1,9 +1,9 @@
-defmodule Sqlite.Ecto.Mixfile do
+defmodule Sqlite.Ecto2.Mixfile do
   use Mix.Project
 
   def project do
     [app: :sqlite_ecto2,
-     version: "2.0.0-dev.1",
+     version: "2.0.0-dev.2",
      name: "Sqlite.Ecto2",
      elixir: "~> 1.3.4 or ~> 1.4",
      elixirc_options: [warnings_as_errors: true],
@@ -20,7 +20,7 @@ defmodule Sqlite.Ecto.Mixfile do
      package: package(),
 
      # docs
-     docs: [main: Sqlite.Ecto]]
+     docs: [main: Sqlite.Ecto2]]
   end
 
   # Configuration for the OTP application

--- a/test/sqlite_ecto_test.exs
+++ b/test/sqlite_ecto_test.exs
@@ -1,33 +1,33 @@
-defmodule Sqlite.Ecto.Test do
+defmodule Sqlite.Ecto2.Test do
   use ExUnit.Case, async: true
 
   # IMPORTANT: This is closely modeled on Ecto's postgres_test.exs file.
   # We strive to avoid structural differences between that file and this one.
 
-  alias Sqlite.Ecto.Connection, as: SQL
+  alias Sqlite.Ecto2.Connection, as: SQL
   alias Ecto.Migration.Table
 
   test "storage up (twice)" do
     tmp = [database: tempfilename()]
-    assert Sqlite.Ecto.storage_up(tmp) == :ok
+    assert Sqlite.Ecto2.storage_up(tmp) == :ok
     assert File.exists? tmp[:database]
-    assert Sqlite.Ecto.storage_up(tmp) == {:error, :already_up}
+    assert Sqlite.Ecto2.storage_up(tmp) == {:error, :already_up}
     File.rm(tmp[:database])
   end
 
   test "storage down (twice)" do
     tmp = [database: tempfilename()]
-    assert Sqlite.Ecto.storage_up(tmp) == :ok
-    assert Sqlite.Ecto.storage_down(tmp) == :ok
+    assert Sqlite.Ecto2.storage_up(tmp) == :ok
+    assert Sqlite.Ecto2.storage_down(tmp) == :ok
     assert not File.exists? tmp[:database]
-    assert Sqlite.Ecto.storage_down(tmp) == {:error, :already_down}
+    assert Sqlite.Ecto2.storage_down(tmp) == {:error, :already_down}
   end
 
   test "storage up creates directory" do
     dir = "/tmp/my_sqlite_ecto_directory/"
     File.rm_rf! dir
     tmp = [database: dir <> tempfilename()]
-    :ok = Sqlite.Ecto.storage_up(tmp)
+    :ok = Sqlite.Ecto2.storage_up(tmp)
     assert File.exists?(dir <> "tmp/") && File.dir?(dir <> "tmp/")
   end
 
@@ -51,10 +51,10 @@ defmodule Sqlite.Ecto.Test do
       field :y, :integer
       field :z, :integer
 
-      has_many :comments, Sqlite.Ecto.Test.Schema2,
+      has_many :comments, Sqlite.Ecto2.Test.Schema2,
         references: :x,
         foreign_key: :z
-      has_one :permalink, Sqlite.Ecto.Test.Schema3,
+      has_one :permalink, Sqlite.Ecto2.Test.Schema3,
         references: :y,
         foreign_key: :id
     end
@@ -64,7 +64,7 @@ defmodule Sqlite.Ecto.Test do
     use Ecto.Schema
 
     schema "schema2" do
-      belongs_to :post, Sqlite.Ecto.Test.Schema,
+      belongs_to :post, Sqlite.Ecto2.Test.Schema,
         references: :x,
         foreign_key: :z
     end
@@ -81,8 +81,8 @@ defmodule Sqlite.Ecto.Test do
   end
 
   defp normalize(query, operation \\ :all, counter \\ 0) do
-    {query, _params, _key} = Ecto.Query.Planner.prepare(query, operation, Sqlite.Ecto, counter)
-    Ecto.Query.Planner.normalize(query, operation, Sqlite.Ecto, counter)
+    {query, _params, _key} = Ecto.Query.Planner.prepare(query, operation, Sqlite.Ecto2, counter)
+    Ecto.Query.Planner.normalize(query, operation, Sqlite.Ecto2, counter)
   end
 
   test "from" do


### PR DESCRIPTION
Discontinue use of name `Sqlite.Ecto` (without the `2`).

BREAKING CHANGE.
