### PR TITLE
Add documentation from sqlite_ecto, to resolve #135

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Add `sqlite_ecto2` as a dependency in your `mix.exs` file.
 
 ```elixir
 def deps do
-  [{:sqlite_ecto2, "~> 2.0.0-dev.0"}]
+  [{:sqlite_ecto2, "~> 2.0.0-dev.2"}]
 end
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+Welcome to the Sqlite.Ecto documentation!
+
+## For Users:
+* [Basic Sqlite.Ecto Tutorial](tutorial.md) - using Sqlite.Ecto for the first time
+* [Using Sqlite.Ecto as a Test Database](using-sqlite.ecto-as-a-test-database.md) - configuring Sqlite.Ecto as a "stub" database for unit tests
+* [Sqlite.Ecto Functionality](sqlite.ecto-functionality.md) - comparison between Sqlite.Ecto and the PostgreSQL adapter
+
+## For Developers:
+* [Sqlite.Ecto's Pseudo-Returning Clause](sqlite.ectos-peudo-returning-clause.md) - how to implement PostgreSQL's `RETURNING` clause with SQLite

--- a/docs/sqlite.ecto-functionality.md
+++ b/docs/sqlite.ecto-functionality.md
@@ -1,0 +1,22 @@
+The table below compares the different functionality available between the PostgreSQL adapter, SQLite adapter (Sqlite.Ecto), and barebones SQLite.  Use it to determine what Ecto functionality you can use with Sqlite.Ecto and whether or not you should consider a more robust database solution, e.g. PostgreSQL, for your application.  There are open issues to extend the functionality of Sqlite.Ecto, and this table will be updated as they are implemented.
+
+| Supported Functionality            | PostgreSQL | Sqlite.Ecto |  SQLite
+|:-----------------------------------|:----------:|:-----------:|:--------:
+| Inner Joins                        |  **Yes**   |   **Yes**   | **Yes**
+| (Left) Outer Joins                 |  **Yes**   |   **Yes**   | **Yes**
+| Right Outer Joins                  |  **Yes**   |      No     |    No
+| Full Outer Joins<sup>1</sup>       |  **Yes**   |      No     |    No
+| Foreign Key Constraints<sup>2</sup>|  **Yes**   |   **Yes**   | Optional
+| `RETURNING` Clause<sup>3</sup>     |  **Yes**   |   **Yes**   |    No
+| Update/Delete w/ Joins<sup>4</sup> |  **Yes**   |      No     |    No
+| `ALTER COLUMN`<sup>5</sup>         |  **Yes**   |      No     |    No
+| `DROP COLUMN`<sup>5</sup>          |  **Yes**   |      No     |    No
+| Locking Clause on Select           |  **Yes**   |      No     |    No
+
+#### Notes
+
+1. A "full outer join" first implements an inner join on two tables.  Then, for any rows from either table that are missing from the result set, it adds those rows to the result set filling in NULLs for any missing values.  There is [an issue](https://github.com/jazzyb/sqlite_ecto/issues/27) to implement this functionality in Sqlite.Ecto.
+2. In SQLite, foreign key constraints must be turned on explicitly for each new database connection with:  `PRAGMA foreign_keys = ON;`.  Sqlite.Ecto does this by default for each connection.
+3. PostgreSQL can return arbitrary values on `INSERT`, `UPDATE`, or `DELETE`.  For example, the statement `INSERT INTO customs (counter, visits) VALUES (10, 11) RETURNING id;` will insert the given values into the `customs` table and then return the `id` for the new row.  SQLite has no support for such a `RETURNING` clause, but it can return the last inserted "rowid" for a table.  Support for returning was added to Sqlite.Ecto in version 0.0.2.  [This article](sqlite.ectos-peudo-returning-clause.md) discusses the method.
+4. There is [an issue](https://github.com/jazzyb/sqlite_ecto/issues/20) to implement `JOIN`s for `INSERT` and `UPDATE` statements.
+5. SQLite does not support modifying or deleting rows in `ALTER TABLE` statements.  The SQLite docs describe [an algorithm](https://www.sqlite.org/lang_altertable.html) for implementing this functionality.  However, the algorithm will require changes to the way foreign key constraints are handled.  [This issue](https://github.com/jazzyb/sqlite_ecto/issues/21) is tracking the necessary changes to Sqlite.Ecto foreign key constraints.

--- a/docs/sqlite.ectos-peudo-returning-clause.md
+++ b/docs/sqlite.ectos-peudo-returning-clause.md
@@ -1,0 +1,106 @@
+## Overview
+
+Ecto relies on a returning clause for its insert, update, and delete statements.  A returning clause in PostgreSQL looks like the following:
+```
+INSERT INTO distributors (did, dname) VALUES (DEFAULT, 'XYZ Widgets') RETURNING did;
+```
+
+The returning clause returns one or more values from each row that was inserted, updated, or deleted with the statement.  SQLite lacks such a clause, but because Ecto uses it often, we must find a way to implement it in Sqlite.Ecto.
+
+## Approach One:  Last Insert Rowid
+
+During my experimentation with Ecto, I only noticed one use of the returning clause -- to return the ID for a row.  SQLite provides a function for returning the last ID that was created due to an insert statement (`last_insert_rowid()` in SQL and `sqlite3_last_insert_rowid()` in the C library).  However, there are a number of drawbacks to this method of returning values:
+
+* The function only returns ID for inserts.  Updates and deletes would still require a different method.
+* The function requires another select statement to return the ID of the inserted row.  If another row is inserted before the select statement to return the last ID, then the value might be wrong.
+* Ecto *may* only use the returning statement for getting IDs from rows **today**, but I don't want my Sqlite.Ecto adapter to rely on an undocumented "feature" of Ecto that may change in the future.
+
+None of these reasons preclude me from utilizing the `last_insert_rowid()` function, but another method will need to be used as well.
+
+## Approach Two:  Secondary Select Statements
+
+Since we know the rows we are updating and deleting (and we can get the rowid of new rows we are inserting), we can issue a select statement before or after statements.
+
+Deletes might look something like this:
+```
+DELETE FROM table WHERE id = 3 RETURNING value;
+```
+which could be converted to:
+```
+SELECT value FROM table WHERE id = 3;
+DELETE FROM table WHERE id = 3;
+```
+
+Updates:
+```
+UPDATE users SET password = 'CHANGE_ME' WHERE password = '' RETURNING id, username;
+```
+to:
+```
+SELECT id, username FROM users WHERE password = '';
+UPDATE users SET password = 'CHANGE_ME' WHERE password = '';
+```
+
+And inserts:
+```
+INSERT INTO users (username, email, password) VALUES ('jazzyb', 'jazzyb@example.com', 'passw0rd') RETURNING id, column_with_default_value;
+```
+to:
+```
+INSERT INTO users (username, email, password) VALUES ('jazzyb', 'jazzyb@example.com', 'passw0rd');
+SELECT id, column_with_default_value FROM users WHERE id IN (SELECT last_insert_rowid());
+```
+
+Furthermore, we could encapsulate the above statements in transactions/savepoints to prevent changes from happening before we could return the correct values from the selects.  This might work, but it requires a good bit of thought on our part to determine the best way to select values for different kinds of queries.  Take the following update for example:
+```
+UPDATE table SET a = 1, b = 2 WHERE b = 3 RETURNING a, b, c;
+```
+
+What is the best way to rewrite it as we have done previously?  Well, even though the where clause tells us which rows will be changed, we have to be mindful of which columns are being updated by the call.  We can't execute the select statement after the call because there may have been other rows where `b = 2` before the update that don't apply to our returning clause.  If we execute the select statement before the update, then we have to anticipate what the new values in the returning clause will be.  It becomes:
+```
+SELECT 1, 2, c FROM table WHERE b = 3;
+UPDATE table SET a = 1, b = 2 WHERE b = 3;
+```
+
+It seems possible to implement the returning clause this way, but working out the logic might not worth our time.  Fortunately, there is a better way.
+
+## Approach Three (and Solution):  Triggers
+
+[Triggers](https://www.sqlite.org/lang_createtrigger.html) are SQL database operations which can be automatically performed when a specified event occurs -- such as an insert, update, or delete on a particular table.  Triggers can access values from a row before or after a statement has been executed.  The solution we use in Sqlite.Ecto to implement the returning clause is the following algorithm (English explanation follows):
+
+```
+SAVEPOINT sp_temp;
+CREATE TEMP TABLE temp.t_temp (col1, col2, ...);
+CREATE TEMP TRIGGER tr_temp AFTER UPDATE ON main.tablename BEGIN
+    INSERT INTO t_temp SELECT NEW.col1, NEW.col2, ...;
+END;
+UPDATE ...;                              -- this is our statement to execute
+DROP TRIGGER tr_temp;
+SELECT col1, col2, ... FROM temp.t_temp; -- these results get saved
+DROP TABLE temp.t_temp;
+RELEASE sp_temp;
+```
+
+1. First, we create a savepoint so that if anything bad happens we can rollback to our prior state.  We use a savepoint instead of a transaction because Ecto issues these statements in transactions, and transactions, unlike savepoints, cannot be nested.
+2. Next, we create a temporary table whose rows contain only the columns we want to return -- `col1`, `col2`, etc. in this example.
+3. Then, we create a temporary trigger which fires after every update on `tablename`.  Of course, this assumes the statement is an update.  Inserts and deletes are declared respectively.  The body of the trigger says to insert the `NEW` values of the row into the temporary table.  Inserts also use `NEW`, but deletes specify `OLD`.
+4. Once all the safety nets are in place, we execute our statement -- in this case an update.
+5. Remove the temporary trigger.
+6. Execute a select statement on the rows saved in the temporary table to get the return values.
+7. Remove the temporary table once we have the results.
+8. And finally, commit the changes.
+
+The advantage of this method is that we don't have to anticipate what values are getting changed for what rows and how they are changing.  We just let SQLite do the work for us, and we reap the results.
+
+### Caveat
+
+There is an important disadvantage to using triggers to implement returning:  **SQLite triggers have an arbitrary order of execution.**  This means that if one has user-defined triggers that change inserted/updated column values, those changes may not be reflected in the returned values because we cannot guarantee that our temporary trigger will fire last.  However, if your application is relying on user-defined triggers, then you probably need a more robust database solution (like Postgres), and SQLite is not for you.  Thus, I believe this is a disadvantage worth having if it means implementing the same functionality as other adapters.
+
+## Syntax of the Returning Clause
+
+There remains one tricky bit to how the *pseudo*-returning clause is implemented.  Ecto executes database commands in two steps:  (1) Call the adapter to convert an Ecto.Query into a SQL string and (2) invoke `Sqlite.Ecto.Connection.query` with the SQL string.  This means that the only access we have to the returning values is in step (1), but the only place we can implement the above algorithm is in step (2).  Thus, we must add our own syntax to represent the returning clause as a part of the SQL string, then in step (2) we must parse the returning clause to reconstruct the columns to return.  The syntax of the returning clause is the following:
+```
+;--RETURNING ON [INSERT | UPDATE | DELETE] tablename,col1,col2,...
+```
+
+Since `;` ends a SQL statement and `--` begins a SQL comment, beginning the pseudo-returning clause with `;--` ensures that the string is still a valid SQLite statement.  The format also lets me easy split the string on `";--RETURNING ON "` to separate the original statement-to-execute from the columns (and table) that we want to return.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -82,7 +82,7 @@ defmodule Blog.Repo.Migrations.CreateUsers do
     create table(:users) do
       add :name, :string
       add :email, :string
-      timestamps
+      timestamps()
     end
   end
 end
@@ -105,7 +105,7 @@ defmodule Blog.User do
   schema "users" do
     field :name, :string
     field :email, :string
-    timestamps
+    timestamps()
   end
 end
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -17,7 +17,7 @@ end
 
 defp deps do
   [{:db_connection, "~> 1.1.0"},
-   {:sqlite_ecto2, "~> 2.0.0-dev.0"}]
+   {:sqlite_ecto2, "~> 2.0.0-dev.2"}]
 end
 ```
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -88,13 +88,13 @@ defmodule Blog.Repo.Migrations.CreateUsers do
 end
 ```
 
-This migration will generate a `users` table with columns for the user's name and email address.  The `timestamps` statement will create timestamps to mark when entries have been inserted or updated.
+This migration will generate a `users` table with columns for the user's name and email address.  The `timestamps()` statement will create timestamps to mark when entries have been inserted or updated.
 
 Run `mix ecto.migrate` to create the new table.  You can verify the migration with the following:
 ```
 $ sqlite3 blog.sqlite3 .schema
-CREATE TABLE "schema_migrations" ("version" BIGINT PRIMARY KEY, "inserted_at" DATETIME);
-CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "email" TEXT, "inserted_at" DATETIME NOT NULL, "updated_at" DATETIME NOT NULL);
+CREATE TABLE "schema_migrations" ("version" BIGINT PRIMARY KEY, "inserted_at" NAIVE_DATETIME);
+CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "email" TEXT, "inserted_at" NAIVE_DATETIME NOT NULL, "updated_at" NAIVE_DATETIME NOT NULL);
 ```
 
 Before we can use the table.  We have to write an Ecto model to encapsulate it.  Edit `lib/blog/user.ex` to define the model:
@@ -113,29 +113,28 @@ end
 Notice how it resembles the migration we just wrote.  Let's quickly make sure the model is working with iex:
 ```
 $ iex -S mix
-Erlang/OTP 17 [erts-6.4.1] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false]
+Erlang/OTP 19 [erts-8.3] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
-Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+Compiling 1 file (.ex)
+Generated blog app
+Interactive Elixir (1.4.1) - press Ctrl+C to exit (type h() ENTER for help)
 iex(1)> Blog.start(nil, nil)
-{:ok, #PID<0.129.0>}
+{:ok, #PID<0.196.0>}
 iex(2)> Blog.Repo.insert(%Blog.User{name: "jazzyb", email: "anonymous@example.com"})
 
-14:55:11.865 [debug] BEGIN [] (31.7ms)
-
-14:55:11.948 [debug] INSERT INTO "users" ("email","inserted_at","name","updated_at") VALUES (?1,?2,?3,?4) ;--RETURNING ON INSERT "users","id" ["anonymous@example.com", {{2015, 5, 20}, {18, 55, 11, 0}}, "jazzyb", {{2015, 5, 20}, {18, 55, 11, 0}}] (23.1ms)
-
-14:55:11.950 [debug] COMMIT [] (1.8ms)
-%Blog.User{__meta__: %Ecto.Schema.Metadata{source: "users", state: :loaded},
- email: "anonymous@example.com", id: 1,
- inserted_at: %Ecto.DateTime{day: 20, hour: 18, min: 55, month: 5, sec: 11,
-  usec: 0, year: 2015}, name: "jazzyb",
- updated_at: %Ecto.DateTime{day: 20, hour: 18, min: 55, month: 5, sec: 11,
-  usec: 0, year: 2015}}
+18:05:16.119 [debug] QUERY OK db=14.7ms
+INSERT INTO "users" ("email","name","inserted_at","updated_at") VALUES (?1,?2,?3,?4) ;--RETURNING ON INSERT "users","id" ["anonymous@example.com", "jazzyb", {{2017, 3, 31}, {8, 5, 16, 78423}}, {{2017, 3, 31}, {8, 5, 16, 86372}}]
+{:ok,
+ %Blog.User{__meta__: #Ecto.Schema.Metadata<:loaded, "users">,
+  email: "anonymous@example.com", id: 1,
+  inserted_at: ~N[2017-03-31 08:05:16.078423], name: "jazzyb",
+  updated_at: ~N[2017-03-31 08:05:16.086372]}}
 iex(3)> import Ecto.Query
-nil
+Ecto.Query
 iex(4)> Blog.Repo.all(Blog.User |> select([user], user.name))
 
-14:56:38.686 [debug] SELECT u0."name" FROM "users" AS u0 [] (0.8ms)
+18:07:32.472 [debug] QUERY OK source="users" db=0.8ms queue=0.1ms
+SELECT u0."name" FROM "users" AS u0 []
 ["jazzyb"]
 iex(5)>
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -306,7 +306,7 @@ defmodule Blog.Repo.Migrations.DistinctUsernames do
 end
 ```
 
-This creates a unique index on `users.name` that prevents two users from having the same username.  We can write another assertion to test this.  After `"ludwig_wittgenstein"` is defined in our test case, verify that we can't create another user with the same name:
+Run `mix ecto.migrate` to apply this migration. This creates a unique index on `users.name` that prevents two users from having the same username.  We can write another assertion to test this.  After `"ludwig_wittgenstein"` is defined in our test case, verify that we can't create another user with the same name:
 ```elixir
     # prevent usernames from overlapping
     assert_raise Sqlite.Ecto.Error, "constraint: UNIQUE constraint failed: users.name", fn ->

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -287,7 +287,8 @@ end
 Let's add a new assertion to our test case to verify we can update our users' passwords:
 ```elixir
     # update user password
-    Repo.update(%User{author | password: "leopoldine"})
+    passwordChange = Ecto.Changeset.change(%User{id: author.id}, password: "leopoldine")
+    Repo.update(passwordChange)
     assert ["leopoldine"] == User
                              |> select([user], user.password)
                              |> where([user], user.id == ^author.id)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -27,17 +27,17 @@ $ mix deps.get
 $ mix ecto.gen.repo -r Blog.Repo
 ```
 
-Edit the Blog.Repo module in `lib/blog/repo.ex` to use the Sqlite.Ecto adapter:
+Edit the Blog.Repo module in `lib/blog/repo.ex` to use the Sqlite.Ecto2 adapter:
 ```elixir
 defmodule Blog.Repo do
-  use Ecto.Repo, otp_app: :blog, adapter: Sqlite.Ecto
+  use Ecto.Repo, otp_app: :blog, adapter: Sqlite.Ecto2
 end
 ```
 
 And change the default PostgreSQL configuration in `config/config.exs` to the following:
 ```elixir
 config :blog, Blog.Repo,
-  adapter: Sqlite.Ecto,
+  adapter: Sqlite.Ecto2,
   database: "blog.sqlite3"
 
 config :blog, ecto_repos: [Blog.Repo]
@@ -316,7 +316,7 @@ end
 Run `mix ecto.migrate` to apply this migration. This creates a unique index on `users.name` that prevents two users from having the same username.  We can write another assertion to test this.  After `"ludwig_wittgenstein"` is defined in our test case, verify that we can't create another user with the same name:
 ```elixir
     # prevent usernames from overlapping
-    assert_raise Sqlite.Ecto.Error, "constraint: UNIQUE constraint failed: users.name", fn ->
+    assert_raise Sqlite.DbConnection.Error, "constraint: UNIQUE constraint failed: users.name", fn ->
       %User{name: "ludwig_wittgenstein", password: "NOT_THE_REAL_USER"} |> Repo.insert
     end
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -205,6 +205,13 @@ defmodule BlogTest do
     {:ok, [pid: pid]}
   end
 
+  setup do
+    on_exit fn ->
+      Repo.delete_all(Post)
+      Repo.delete_all(User)
+    end
+  end
+
   test "that everything works as it should" do
     # assert we can insert and query a user
     {:ok, author} = %User{name: "ludwig_wittgenstein", email: "sharp_witt@example.de"} |> Repo.insert

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -100,7 +100,7 @@ CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "emai
 Before we can use the table.  We have to write an Ecto model to encapsulate it.  Edit `lib/blog/user.ex` to define the model:
 ```elixir
 defmodule Blog.User do
-  use Ecto.Model
+  use Ecto.Schema
 
   schema "users" do
     field :name, :string
@@ -153,7 +153,7 @@ defmodule Blog.Repo.Migrations.CreatePosts do
       add :title, :string
       add :body, :string
       add :user_id, references(:users)
-      timestamps
+      timestamps()
     end
   end
 end
@@ -162,14 +162,14 @@ end
 And run `mix ecto.migrate` to create the posts table, then write the Post model to `lib/blog/post.ex` like so:
 ```elixir
 defmodule Blog.Post do
-  use Ecto.Model
+  use Ecto.Schema
   alias Blog.User
 
   schema "posts" do
     belongs_to :user, User
     field :title, :string
     field :body, :string
-    timestamps
+    timestamps()
   end
 end
 ```
@@ -177,14 +177,14 @@ end
 Notice that in both the migration and the model, we define an association that "posts belong to users".  We also need to define a reverse association that says "users have multiple posts".  Edit the User model at `lib/blog/user.ex` to add the association with the Post model:
 ```elixir
 defmodule Blog.User do
-  use Ecto.Model
+  use Ecto.Schema
   alias Blog.Post
 
   schema "users" do
     has_many :posts, Post
     field :name, :string
     field :email, :string
-    timestamps
+    timestamps()
   end
 end
 ```
@@ -271,7 +271,7 @@ Run `mix ecto.migrate` and verify the new column has been added to the table.  *
 Before we can use the new table we need to update our model.  The User model at `lib/blog/user.ex` should now look like the following:
 ```elixir
 defmodule Blog.User do
-  use Ecto.Model
+  use Ecto.Schema
   alias Blog.Post
 
   schema "users" do
@@ -279,7 +279,7 @@ defmodule Blog.User do
     field :name, :string
     field :email, :string
     field :password, :string, [default: "CHANGE_ME", null: false]
-    timestamps
+    timestamps()
   end
 end
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -12,18 +12,19 @@ Let's create our new Elixir code with mix:  `mix new blog`.  Change into the new
 
 ```elixir
 def application do
-  [applications: [:logger, :sqlite_ecto, :ecto]]
+  [applications: [:logger, :sqlite_ecto2, :ecto]]
 end
 
 defp deps do
-  [{:sqlite_ecto, "~> 0.5.0"}]
+  [{:db_connection, "~> 1.1.0"},
+   {:sqlite_ecto2, "~> 2.0.0-dev.0"}]
 end
 ```
 
 Now make sure you can download your dependencies, compile, and setup your Ecto repository:
 ```
 $ mix deps.get
-$ mix ecto.gen.repo Blog.Repo
+$ mix ecto.gen.repo -r Blog.Repo
 ```
 
 Edit the Blog.Repo module in `lib/blog/repo.ex` to use the Sqlite.Ecto adapter:
@@ -38,9 +39,13 @@ And change the default PostgreSQL configuration in `config/config.exs` to the fo
 config :blog, Blog.Repo,
   adapter: Sqlite.Ecto,
   database: "blog.sqlite3"
+
+config :blog, ecto_repos: [Blog.Repo]
 ```
 
-In this example `blog.sqlite3` is the SQLite file that will store our blog's database.  The file will be created in the top-level directory.  You can change it to any file path you like.
+In this example `blog.sqlite3` is the SQLite file that will store our blog's database.  The file will be created in the
+top-level directory.  You can change it to any file path you like. Adding the `:ecto_repos` key with `[Blog.Repo]` tells
+Ecto's `mix` tasks about the `Blog.Repo` database.
 
 Fill in `lib/blog.ex` to start the Ecto repo when the application starts:
 ```elixir

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,310 @@
+## Introduction
+
+Sqlite.Ecto is an Ecto adapter which helps you to interact with SQLite databases.
+
+This very brief tutorial will walk you through the basics of configuring and using Ecto with SQLite.  We are going to setup a very basic schema that one might need for a blog.  The following assumes you already have some familiarity with Elixir development.
+
+**PLEASE NOTE** that the following schema, configuration, and associated tests are in no way secure or robust and should not be used for a production database.  They are only being used to demonstrate some of the features of Ecto.
+
+## Configuring Ecto
+
+Let's create our new Elixir code with mix:  `mix new blog`.  Change into the new directory and update the `mix.exs` file to use Ecto and SQLite:
+
+```elixir
+def application do
+  [applications: [:logger, :sqlite_ecto, :ecto]]
+end
+
+defp deps do
+  [{:sqlite_ecto, "~> 0.5.0"}]
+end
+```
+
+Now make sure you can download your dependencies, compile, and setup your Ecto repository:
+```
+$ mix deps.get
+$ mix ecto.gen.repo Blog.Repo
+```
+
+Edit the Blog.Repo module in `lib/blog/repo.ex` to use the Sqlite.Ecto adapter:
+```elixir
+defmodule Blog.Repo do
+  use Ecto.Repo, otp_app: :blog, adapter: Sqlite.Ecto
+end
+```
+
+And change the default PostgreSQL configuration in `config/config.exs` to the following:
+```elixir
+config :blog, Blog.Repo,
+  adapter: Sqlite.Ecto,
+  database: "blog.sqlite3"
+```
+
+In this example `blog.sqlite3` is the SQLite file that will store our blog's database.  The file will be created in the top-level directory.  You can change it to any file path you like.
+
+Fill in `lib/blog.ex` to start the Ecto repo when the application starts:
+```elixir
+defmodule Blog do
+  use Application
+
+  # See http://elixir-lang.org/docs/stable/elixir/Application.html
+  # for more information on OTP Applications
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    children = [
+      worker(Blog.Repo, [])
+    ]
+
+    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: Blog.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end
+```
+
+Run `mix ecto.create`.  Verify that the SQLite database has been created at `blog.sqlite3` or wherever you have configured your database to be written.
+
+## Ecto Models
+
+Now that we have our database configured and created, we can create tables to hold our data.  Let's start by creating a "users" database table.  Run `mix ecto.gen.migration create_users`.  This will create a file at `priv/repo/migrations/TIMESTAMP_create_users.exs` where `TIMESTAMP` is the particular date and time you ran the migration command.  Edit this file to create the new table:
+```elixir
+defmodule Blog.Repo.Migrations.CreateUsers do
+  use Ecto.Migration
+
+  def change do
+    create table(:users) do
+      add :name, :string
+      add :email, :string
+      timestamps
+    end
+  end
+end
+```
+
+This migration will generate a `users` table with columns for the user's name and email address.  The `timestamps` statement will create timestamps to mark when entries have been inserted or updated.
+
+Run `mix ecto.migrate` to create the new table.  You can verify the migration with the following:
+```
+$ sqlite3 blog.sqlite3 .schema
+CREATE TABLE "schema_migrations" ("version" BIGINT PRIMARY KEY, "inserted_at" DATETIME);
+CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "email" TEXT, "inserted_at" DATETIME NOT NULL, "updated_at" DATETIME NOT NULL);
+```
+
+Before we can use the table.  We have to write an Ecto model to encapsulate it.  Edit `lib/blog/user.ex` to define the model:
+```elixir
+defmodule Blog.User do
+  use Ecto.Model
+
+  schema "users" do
+    field :name, :string
+    field :email, :string
+    timestamps
+  end
+end
+```
+
+Notice how it resembles the migration we just wrote.  Let's quickly make sure the model is working with iex:
+```
+$ iex -S mix
+Erlang/OTP 17 [erts-6.4.1] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false]
+
+Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
+iex(1)> Blog.start(nil, nil)
+{:ok, #PID<0.129.0>}
+iex(2)> Blog.Repo.insert(%Blog.User{name: "jazzyb", email: "anonymous@example.com"})
+
+14:55:11.865 [debug] BEGIN [] (31.7ms)
+
+14:55:11.948 [debug] INSERT INTO "users" ("email","inserted_at","name","updated_at") VALUES (?1,?2,?3,?4) ;--RETURNING ON INSERT "users","id" ["anonymous@example.com", {{2015, 5, 20}, {18, 55, 11, 0}}, "jazzyb", {{2015, 5, 20}, {18, 55, 11, 0}}] (23.1ms)
+
+14:55:11.950 [debug] COMMIT [] (1.8ms)
+%Blog.User{__meta__: %Ecto.Schema.Metadata{source: "users", state: :loaded},
+ email: "anonymous@example.com", id: 1,
+ inserted_at: %Ecto.DateTime{day: 20, hour: 18, min: 55, month: 5, sec: 11,
+  usec: 0, year: 2015}, name: "jazzyb",
+ updated_at: %Ecto.DateTime{day: 20, hour: 18, min: 55, month: 5, sec: 11,
+  usec: 0, year: 2015}}
+iex(3)> import Ecto.Query
+nil
+iex(4)> Blog.Repo.all(Blog.User |> select([user], user.name))
+
+14:56:38.686 [debug] SELECT u0."name" FROM "users" AS u0 [] (0.8ms)
+["jazzyb"]
+iex(5)>
+```
+
+In the above output, we start the Blog.Repo (1), create a new user `jazzyb` (2), and then verify that we can query that user from the database (4).
+
+## Associations
+
+Now that we have some basic understanding of models, let's complicate the schema a little bit.  If we want to create a blog, we have to have some posts that users can write.  Let's create a new migration to generate the posts table with `mix ecto.gen.migration create_posts`.  Edit the resulting file:
+```elixir
+defmodule Blog.Repo.Migrations.CreatePosts do
+  use Ecto.Migration
+
+  def change do
+    create table(:posts) do
+      add :title, :string
+      add :body, :string
+      add :user_id, references(:users)
+      timestamps
+    end
+  end
+end
+```
+
+And run `mix ecto.migrate` to create the posts table, then write the Post model to `lib/blog/post.ex` like so:
+```elixir
+defmodule Blog.Post do
+  use Ecto.Model
+  alias Blog.User
+
+  schema "posts" do
+    belongs_to :user, User
+    field :title, :string
+    field :body, :string
+    timestamps
+  end
+end
+```
+
+Notice that in both the migration and the model, we define an association that "posts belong to users".  We also need to define a reverse association that says "users have multiple posts".  Edit the User model at `lib/blog/user.ex` to add the association with the Post model:
+```elixir
+defmodule Blog.User do
+  use Ecto.Model
+  alias Blog.Post
+
+  schema "users" do
+    has_many :posts, Post
+    field :name, :string
+    field :email, :string
+    timestamps
+  end
+end
+```
+
+The models are getting more complicated, so let's write a test to make sure we can add entries to our repo and make sure everything is working as it should.  Edit `test/blog_test.exs` and add the following:
+```elixir
+defmodule BlogTest do
+  use ExUnit.Case
+
+  alias Blog.Repo
+  alias Blog.User
+  alias Blog.Post
+
+  import Ecto.Query
+
+  setup_all do
+    {:ok, pid} = Blog.start(nil, nil)
+    {:ok, [pid: pid]}
+  end
+
+  test "that everything works as it should" do
+    # assert we can insert and query a user
+    {:ok, author} = %User{name: "ludwig_wittgenstein", email: "sharp_witt@example.de"} |> Repo.insert
+    ["ludwig_wittgenstein"] = User |> select([user], user.name) |> Repo.all
+
+    # assert we can insert posts
+    Repo.insert(%Post{user_id: author.id, title: "Tractatus", body: "Nothing to say."})
+    Repo.insert(%Post{user_id: author.id, title: "Tractatus", body: "Nothing else to say."})
+    Repo.insert(%Post{user_id: author.id, title: "Tractatus", body: "Nothing more to say."})
+    assert List.duplicate("Tractatus", 3) == Post
+                                             |> select([post], post.title)
+                                             |> where([post], post.user_id == ^author.id)
+                                             |> Repo.all
+
+    # ... and one more post and user for good measure
+    {:ok, user} = %User{name: "john_cusack", email: "cusack66@example.com"} |> Repo.insert
+    Repo.insert(%Post{user_id: user.id, title: "Trashy 80's Romance", body: "Say anything."})
+    assert ["Trashy 80's Romance"] == Post
+                                      |> select([post], post.title)
+                                      |> where([post], post.user_id == ^user.id)
+                                      |> Repo.all
+  end
+end
+```
+
+This test shows how to insert entries into your database and query it for information.  Run it with `mix test` to see that everything is working alright.  **NOTE**  You may need to re-migrate the database if you run into errors involving entries you've added in the past.  If this is the case, just do the following to delete the old database and create a new pristine one:
+```
+$ mix ecto.drop
+$ mix ecto.create
+$ mix ecto.migrate
+```
+
+Now that we know everything works as it should, let's see what we can do with the associations we defined between User and Post.  Write a new assertion at the end of the test which queries for all the posts of a particular user:
+```elixir
+    # preload user posts
+    query = from u in User, where: u.id == ^author.id, preload: [:posts]
+    titles = query
+    |> Repo.all
+    |> Enum.map(fn user -> user.posts end)
+    |> List.flatten
+    |> Enum.map(fn post -> post.title end)
+    assert List.duplicate("Tractatus", 3) == titles
+```
+
+In the example above, the `preload` command in the query fills in the `posts` value when we query for a user.  Then the assertion does some overly complicated code to get the titles of all of user `author`'s posts.  The associations we defined earlier are what give us access to the posts through user.
+
+## Making Changes to the Database
+
+What if we want to add values for our users, like, requiring passwords to access the blog?  We can add columns to tables using migrations.  Create a new migration with `mix ecto.gen.migration user_passwords` and edit the result:
+```elixir
+defmodule Blog.Repo.Migrations.UserPasswords do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :password, :string, [default: "CHANGE_ME", null: false]
+    end
+  end
+end
+```
+
+Run `mix ecto.migrate` and verify the new column has been added to the table.  **NOTE**  Sqlite.Ecto can only add columns to tables -- it cannot remove or modify columns once they have been created.
+
+Before we can use the new table we need to update our model.  The User model at `lib/blog/user.ex` should now look like the following:
+```elixir
+defmodule Blog.User do
+  use Ecto.Model
+  alias Blog.Post
+
+  schema "users" do
+    has_many :posts, Post
+    field :name, :string
+    field :email, :string
+    field :password, :string, [default: "CHANGE_ME", null: false]
+    timestamps
+  end
+end
+```
+
+Let's add a new assertion to our test case to verify we can update our users' passwords:
+```elixir
+    # update user password
+    Repo.update(%User{author | password: "leopoldine"})
+    assert ["leopoldine"] == User
+                             |> select([user], user.password)
+                             |> where([user], user.id == ^author.id)
+                             |> Repo.all
+```
+
+We have another problem as our schema stands:  There is nothing preventing users from sharing the same username.  That could get very confusing.  We can fix that in Ecto by creating a unique index.  Run `mix ecto.gen.migration distinct_usernames` and edit the resulting file:
+```elixir
+defmodule Blog.Repo.Migrations.DistinctUsernames do
+  use Ecto.Migration
+
+  def change do
+    create index(:users, [:name], unique: true)
+  end
+end
+```
+
+This creates a unique index on `users.name` that prevents two users from having the same username.  We can write another assertion to test this.  After `"ludwig_wittgenstein"` is defined in our test case, verify that we can't create another user with the same name:
+```elixir
+    # prevent usernames from overlapping
+    assert_raise Sqlite.Ecto.Error, "constraint: UNIQUE constraint failed: users.name", fn ->
+      %User{name: "ludwig_wittgenstein", password: "NOT_THE_REAL_USER"} |> Repo.insert
+    end
+```

--- a/docs/using-sqlite.ecto-as-a-test-database.md
+++ b/docs/using-sqlite.ecto-as-a-test-database.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-SQLite isn't the best choice of a database for most production applications.  However, SQLite *can* make a great stub database for unit testing.  This short article will explain how to setup the Blog application from the [Basic Sqlite.Ecto Tutorial](tutorial.md) with a production PostgreSQL database and a separate test SQLite database.
+SQLite isn't the best choice of a database for most production applications.  However, SQLite *can* make a great stub database for unit testing.  This short article will explain how to setup the Blog application from the [Basic Sqlite.Ecto2 Tutorial](tutorial.md) with a production PostgreSQL database and a separate test SQLite database.
 
 (**NOTE:**  Although it is not required to read the basic tutorial first, this article will assume some familiarity with the general layout of that source code.)
 
@@ -37,7 +37,7 @@ Create `config/test.exs`:
 ```elixir
 use Mix.Config
 
-config :blog, :ecto_adapter, Sqlite.Ecto
+config :blog, :ecto_adapter, Sqlite.Ecto2
 
 config :blog, Blog.Repo,
   adapter: Application.get_env(:blog, :ecto_adapter),
@@ -71,7 +71,7 @@ Finally, all that remains is to update `mix.exs` with our new environmental conf
 ```elixir
   def application do
     case Mix.env do
-      :test -> [applications: [:logger, :sqlite_ecto, :ecto]]
+      :test -> [applications: [:logger, :sqlite_ecto2, :ecto]]
       :prod -> [applications: [:logger, :postgrex, :ecto]]
     end
   end

--- a/docs/using-sqlite.ecto-as-a-test-database.md
+++ b/docs/using-sqlite.ecto-as-a-test-database.md
@@ -1,0 +1,101 @@
+## Introduction
+
+SQLite isn't the best choice of a database for most production applications.  However, SQLite *can* make a great stub database for unit testing.  This short article will explain how to setup the Blog application from the [Basic Sqlite.Ecto Tutorial](tutorial.md) with a production PostgreSQL database and a separate test SQLite database.
+
+(**NOTE:**  Although it is not required to read the basic tutorial first, this article will assume some familiarity with the general layout of that source code.)
+
+## Caveat
+
+As of Ecto 0.16.0 there are enough differences between how the Postgres and SQLite adapters work, even for functionality that they share, that I suggest you not use SQLite for your development database if it is not also your production database.  Having said that, SQLite might still be useful as a mock resource for some unit tests -- in which case this article may still have merit.  See [this StackOverflow discussion](http://stackoverflow.com/questions/10859186/sqlite-in-development-postgresql-in-production-why-not) and decide for yourself.
+
+## Background:  The Mix Environment
+
+Before we start, let's make sure we understand the Mix environment.  Mix provides three different environments to prepare and run your application for.  They are:
+* `:dev` -- the default environment
+* `:test` -- the environment in which `mix test` runs
+* `:prod` -- the environment and configuration with which your production application will run
+
+By setting the value of the `MIX_ENV` environment variable, we can prepare and run our Elixir application with different configurations.  For example, while `mix test` will run our tests using the test database by default, `MIX_ENV=prod mix test` will run the same tests against a production database we have configured.
+
+## Configuration
+
+Let's start with the config files.  If your application is small or you've just started development, you probably have all your application configuration in the default `config/config.exs` file.  We are going to have this file import different configuration files based on the value of the `MIX_ENV` environment variable.  Edit your `config/config.exs` file like so:
+
+```elixir
+use Mix.Config
+
+# ... general, environment-independent configuration goes here ...
+
+import_config "#{Mix.env}.exs"
+```
+
+The `import_config` statement should go to the bottom of the file so that it will overwrite any of the generic configuration above it.  Next we create separate config files for each of the different environments.
+
+(**NOTE:**  We are ignoring `:dev` for the remainder of this article, but you should account for it in your own configs.)
+
+Create `config/test.exs`:
+```elixir
+use Mix.Config
+
+config :blog, :ecto_adapter, Sqlite.Ecto
+
+config :blog, Blog.Repo,
+  adapter: Application.get_env(:blog, :ecto_adapter),
+  database: "test/blog.sqlite3",
+  size: 1,
+  max_overflow: 0
+```
+
+And create `config/prod.exs`:
+```elixir
+use Mix.Config
+
+config :blog, :ecto_adapter, Ecto.Adapters.Postgres
+
+config :blog, Blog.Repo,
+  adapter: Application.get_env(:blog, :ecto_adapter),
+  database: "blog",
+  username: "postgres",
+  password: "postgres"
+```
+
+Notice that in each of the configs we created a different application environment variable called `:ecto_adapter`.  Now wherever we had hardcoded our adapter, we can instead access different adapters based on our environment.  Edit the Repo at `lib/blog/repo.ex` to do just that:
+```elixir
+defmodule Blog.Repo do
+  use Ecto.Repo, otp_app: :blog,
+                 adapter: Application.get_env(:blog, :ecto_adapter)
+end
+```
+
+Finally, all that remains is to update `mix.exs` with our new environmental configuration.  Change the `application/0` function to include different projects based on the environment:
+```elixir
+  def application do
+    case Mix.env do
+      :test -> [applications: [:logger, :sqlite_ecto, :ecto]]
+      :prod -> [applications: [:logger, :postgrex, :ecto]]
+    end
+  end
+```
+
+And change the `deps/0` function to set different dependencies depending on environment:
+```elixir
+  defp deps do
+    [{:sqlite_ecto, "0.0.2", only: :test},
+     {:postgrex, ">= 0.0.0", only: :prod},
+     {:ecto, "~> 0.11"}]
+  end
+```
+
+You may need to run `MIX_ENV=prod mix deps.get` afterwards to install the Postgrex dependency.
+
+Provided you have the PostgreSQL server properly configured, you can run the following commands in turn to run your tests against your production database:
+```
+$ export MIX_ENV=prod
+$ mix ecto.create
+$ mix ecto.migrate
+$ mix test
+```
+
+The `export` line sets the environment variable without having to append `MIX_ENV=prod ` before every command.  Replace `prod` with `test` to run against the SQLite test database.
+
+That's all it takes to use different database adapters for testing and production!  Now if you desire, you can test or develop locally with SQLite and then use a PostgreSQL database in production without ever having to change your code.  SQLite even provides support for in-memory databases, so depending on your use-case, you may not even need the `blog.sqlite3` test file for your unit tests.

--- a/docs/using-sqlite.ecto-as-a-test-database.md
+++ b/docs/using-sqlite.ecto-as-a-test-database.md
@@ -80,7 +80,7 @@ Finally, all that remains is to update `mix.exs` with our new environmental conf
 And change the `deps/0` function to set different dependencies depending on environment:
 ```elixir
   defp deps do
-    [{:sqlite_ecto2, "~> 2.0.0-dev.0", only: :test},
+    [{:sqlite_ecto2, "~> 2.0.0-dev.2", only: :test},
      {:postgrex, ">= 0.0.0", only: :prod},
      {:ecto, "~> 2.1.0"}]
   end

--- a/docs/using-sqlite.ecto-as-a-test-database.md
+++ b/docs/using-sqlite.ecto-as-a-test-database.md
@@ -80,9 +80,9 @@ Finally, all that remains is to update `mix.exs` with our new environmental conf
 And change the `deps/0` function to set different dependencies depending on environment:
 ```elixir
   defp deps do
-    [{:sqlite_ecto, "0.0.2", only: :test},
+    [{:sqlite_ecto2, "~> 2.0.0-dev.0", only: :test},
      {:postgrex, ">= 0.0.0", only: :prod},
-     {:ecto, "~> 0.11"}]
+     {:ecto, "~> 2.1.0"}]
   end
 ```
 


### PR DESCRIPTION
Addition of sqlite_ecto documentation in docs directory as Markdown, updated for sqlite_ecto2 as discussed in #135.