### PR TITLE
Make db_connection a hard dependency. (Fixes #174.)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Sqlite.Ecto2.Mixfile do
     [{:connection, "~> 1.0.3"},
      {:coverex, "~> 1.4.11", only: :test},
      {:credo, "~> 0.7", only: [:dev, :test]},
-     {:db_connection, "~> 1.1.0", optional: true},
+     {:db_connection, "~> 1.1.0"},
      {:decimal, "~> 1.2"},
      {:dogma, "~> 0.1", only: :dev},
      {:esqlite, "~> 0.2.3"},


### PR DESCRIPTION
Though using other DB connection pooling mechanisms is technically possible, IMHO most users (including the test suite here) use db_connection, so the cost is really included unnecessary code in that case.

Will welcome a well-crafted PR reversing this if anybody has such a need.