### PR TITLE
Add sqlitex to applications in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Sqlite.Ecto2.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [applications: [:db_connection, :ecto, :logger],
+    [applications: [:db_connection, :ecto, :logger, :sqlitex],
      mod: {Sqlite.DbConnection.App, []}]
   end
 


### PR DESCRIPTION
This is needed for sqlite_ecto2 to work properly in an OTP release.
Without this sqlitex won't be included in the release, and sqlite_ecto2
will not work.