### PR TITLE
Fix README example schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ defmodule Repo do
 end
 
 defmodule Weather do
-  use Ecto.Model
+  use Ecto.Schema
 
   schema "weather" do
     field :city     # Defaults to type :string


### PR DESCRIPTION
Since Ecto 2.0 the model module doesn't exist anymore. Instead Ecto.Schema is used