### PR TITLE
Closes #202 - Basic support for UNIQUE constraint changeset errors.

### DIFF
--- a/lib/sqlite_ecto/connection.ex
+++ b/lib/sqlite_ecto/connection.ex
@@ -14,6 +14,13 @@ if Code.ensure_loaded?(Sqlitex.Server) do
       DBConnection.child_spec(Sqlite.DbConnection.Protocol, opts)
     end
 
+    def to_constraints(%Sqlite.DbConnection.Error{sqlite: %{code: :constraint}, message: message}) do
+      case :binary.split(message, " constraint failed: ") do
+        ["UNIQUE", field] -> [unique: String.replace(field, ".", "_") <> "_index"]
+        _ -> []
+      end
+    end
+
     def to_constraints(_), do: []
 
     ## Query


### PR DESCRIPTION
This is a simple change that would only take care of the UNIQUE constraint in the default case (when the table index name was not overridden). Not sure about other cases as I haven't yet encountered them.